### PR TITLE
1.11.0 release 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,8 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        rust: [stable, beta, nightly, 1.83.0, 1.65.0, 1.61.0, 1.57.0]
+          # TODO: add stable/beta once they're versions >= 1.83 
+        rust: [beta, nightly, 1.83.0, 1.65.0, 1.61.0, 1.57.0]
 
     steps:
     - uses: actions/checkout@v2
@@ -68,12 +69,12 @@ jobs:
           "rust_stable adt_const_marker alloc"
 
         cargo test --no-default-features --features \
-          "rust_stable adt_const_marker proc_macros __ui_tests alloc"
-          # "rust_stable adt_const_marker proc_macros          alloc"
+          "rust_stable adt_const_marker proc_macros              alloc"
+          # "rust_stable adt_const_marker proc_macros __ui_tests alloc"
 
         cargo test --no-default-features --features \
-          "rust_stable adt_const_marker             __ui_tests alloc"
-          # "rust_stable adt_const_marker                      alloc"
+          "rust_stable adt_const_marker                        alloc"
+          # "rust_stable adt_const_marker           __ui_tests alloc"
 
         MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
         echo "Installing latest nightly with Miri"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        rust: [stable, beta, nightly, 1.65.0, 1.61.0, 1.57.0]
+        rust: [stable, beta, nightly, 1.83.0, 1.65.0, 1.61.0, 1.57.0]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,6 +28,10 @@ jobs:
     - name: enable-rust-1_65
       if: matrix.rust == '1.65.0'
       run: echo "rustv=rust_1_65" >> $GITHUB_ENV
+
+    - name: enable-rust-1_83
+      if: matrix.rust == '1.83.0'
+      run: echo "rustv=rust_1_83" >> $GITHUB_ENV
 
     - name: enable-rust-stable
       if: matrix.rust == 'stable' || matrix.rust == 'beta' || matrix.rust == 'nightly'
@@ -59,15 +63,15 @@ jobs:
         cargo build
         
         cargo test --no-default-features --features \
-          "rust_stable adt_const_marker nightly_mut_refs"
+          "rust_stable adt_const_marker"
         cargo test --no-default-features --features \
-          "rust_stable adt_const_marker alloc nightly_mut_refs"
+          "rust_stable adt_const_marker alloc"
 
         cargo test --no-default-features --features \
-          "rust_stable adt_const_marker proc_macros __ui_tests alloc nightly_mut_refs"
+          "rust_stable adt_const_marker proc_macros __ui_tests alloc"
 
         cargo test --no-default-features --features \
-          "rust_stable adt_const_marker             __ui_tests alloc nightly_mut_refs"
+          "rust_stable adt_const_marker             __ui_tests alloc"
 
         MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
         echo "Installing latest nightly with Miri"
@@ -81,4 +85,4 @@ jobs:
         cargo clean 
 
         env RUST_BACKTRACE=0 cargo miri test --no-default-features \
-            --features "${{env.rustv}} adt_const_marker proc_macros alloc nightly_mut_refs"
+            --features "${{env.rustv}} adt_const_marker proc_macros alloc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,8 @@ version = "1.0"
 default = ["proc_macros"]
 rust_1_61 = []
 rust_1_65 = ["rust_1_61"]
-rust_stable = ["rust_1_65"]
+rust_1_83 = ["rust_1_65"]
+rust_stable = ["rust_1_83"]
 proc_macros = ["typewit_proc_macros"]
 const_marker = []
 adt_const_marker = ["rust_stable"]
@@ -44,8 +45,9 @@ alloc = []
 mut_refs = ["rust_stable"]
 nightly_mut_refs = ["mut_refs"]
 docsrs = []
+
 __ui_tests = []
 
 [package.metadata.docs.rs]
-features = ["alloc", "rust_stable", "nightly_mut_refs", "adt_const_marker", "docsrs"]
+features = ["alloc", "rust_stable", "adt_const_marker", "docsrs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "typewit"
-<<<<<<< HEAD
-version = "1.10.0"
-=======
-version = "1.10.1"
->>>>>>> main
+version = "1.11.0"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 rust-version = "1.57.0"
 edition = "2021"
@@ -51,12 +47,7 @@ alloc = []
 mut_refs = ["rust_stable"]
 nightly_mut_refs = ["mut_refs"]
 docsrs = []
-<<<<<<< HEAD
-
-__ui_tests = []
-=======
 __ui_tests = ["trybuild"]
->>>>>>> main
 
 [package.metadata.docs.rs]
 features = ["alloc", "rust_stable", "adt_const_marker", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typewit"
-version = "1.9.0"
+version = "1.10.0"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 rust-version = "1.57.0"
 edition = "2021"

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,15 @@ This is the changelog, summarising changes in each version(some minor changes ma
 
 Added `"rust_1_83"` feature, which turns `typewit` functions that use `&mut` into const fns.
 
+Added these methods to `BoolWitG`: 
+- `is_true`
+- `is_false`
+- `to_true`
+- `to_false`
+- `unwrap_true`
+- `unwrap_false`
+
+Relaxed `Copy + Clone + Debug` impls of `BooleanWitG` to work for any `<B> BooleanWitG<B>`, instead of requirning `<const B: bool> BoolWitG<Bool<B>>`.
 
 
 ### 1.10.1

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,7 @@ Added these methods to `BoolWitG`:
 - `unwrap_true`
 - `unwrap_false`
 
-Relaxed `Copy + Clone + Debug` impls of `BooleanWitG` to work for any `<B> BooleanWitG<B>`, instead of requirning `<const B: bool> BoolWitG<Bool<B>>`.
+Relaxed `Copy + Clone + Debug` impls of `BooleanWitG` to work for any `<B> BooleanWitG<B>`, instead of requiring `<const B: bool> BoolWitG<Bool<B>>`.
 
 
 ### 1.10.1

--- a/src/const_marker/boolwit.rs
+++ b/src/const_marker/boolwit.rs
@@ -201,15 +201,61 @@ pub enum BoolWitG<B> {
     False(TypeEq<B, Bool<false>>),
 }
 
-impl<const B: bool> Copy for  BoolWitG<Bool<B>> {}
+impl<B> BoolWitG<B> {
+    /// Whether `B == Bool<true>`
+    pub const fn is_true(self) -> bool {
+        matches!(self, Self::True{..})
+    }
 
-impl<const B: bool> Clone for  BoolWitG<Bool<B>> {
+    /// Whether `B == Bool<false>`
+    pub const fn is_false(self) -> bool {
+        matches!(self, Self::False{..})
+    }
+
+    /// Gets a proof of `B == Bool<true>`, returns None if `B == Bool<false>`
+    pub const fn to_true(self) -> Option<TypeEq<B, Bool<true>>> {
+        match self {
+            Self::True(x) => Some(x),
+            _ => None
+        }
+    }
+
+    /// Gets a proof of `B == Bool<false>`, returns None if `B == Bool<true>`
+    pub const fn to_false(self) -> Option<TypeEq<B, Bool<false>>> {
+        match self {
+            Self::False(x) => Some(x),
+            _ => None
+        }
+    }
+
+
+    /// Gets a proof of `B == Bool<true>`, panics if `B == Bool<false>`
+    pub const fn unwrap_true(self) -> TypeEq<B, Bool<true>> {
+        match self {
+            Self::True(x) => x,
+            _ => panic!("attempted to unwrap into True on False variant")
+        }
+    }
+
+    /// Gets a proof of `B == Bool<false>`, panics if `B == Bool<true>`
+    pub const fn unwrap_false(self) -> TypeEq<B, Bool<false>> {
+        match self {
+            Self::False(x) => x,
+            _ => panic!("attempted to unwrap into False on True variant")
+        }
+    }
+
+}
+
+impl<B> Copy for BoolWitG<B> {}
+
+impl<B> Clone for BoolWitG<B> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<const B: bool> Debug for BoolWitG<Bool<B>> {
+impl<B> Debug for BoolWitG<B> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match self {
             Self::True{..} => "True",

--- a/src/const_marker/boolwit.rs
+++ b/src/const_marker/boolwit.rs
@@ -203,45 +203,111 @@ pub enum BoolWitG<B> {
 
 impl<B> BoolWitG<B> {
     /// Whether `B == Bool<true>`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use typewit::{const_marker::BoolWitG, TypeEq};
+    /// 
+    /// assert_eq!(BoolWitG::True(TypeEq::NEW).is_true(), true);
+    /// assert_eq!(BoolWitG::False(TypeEq::NEW).is_true(), false);
+    /// ```
+    ///
     pub const fn is_true(self) -> bool {
         matches!(self, Self::True{..})
     }
 
     /// Whether `B == Bool<false>`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use typewit::{const_marker::BoolWitG, TypeEq};
+    /// 
+    /// assert_eq!(BoolWitG::True(TypeEq::NEW).is_false(), false);
+    /// assert_eq!(BoolWitG::False(TypeEq::NEW).is_false(), true);
+    /// ```
+    ///
     pub const fn is_false(self) -> bool {
         matches!(self, Self::False{..})
     }
 
     /// Gets a proof of `B == Bool<true>`, returns None if `B == Bool<false>`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use typewit::{const_marker::{Bool, BoolWitG}, TypeEq};
+    /// 
+    /// assert_eq!(BoolWitG::True(TypeEq::NEW).to_true(), Some(TypeEq::new::<Bool<true>>()));
+    /// assert_eq!(BoolWitG::False(TypeEq::NEW).to_true(), None);
+    /// ```
+    ///
     pub const fn to_true(self) -> Option<TypeEq<B, Bool<true>>> {
         match self {
             Self::True(x) => Some(x),
-            _ => None
+            Self::False{..} => None
         }
     }
 
     /// Gets a proof of `B == Bool<false>`, returns None if `B == Bool<true>`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use typewit::{const_marker::{Bool, BoolWitG}, TypeEq};
+    /// 
+    /// assert_eq!(BoolWitG::True(TypeEq::NEW).to_false(), None);
+    /// assert_eq!(BoolWitG::False(TypeEq::NEW).to_false(), Some(TypeEq::new::<Bool<false>>()));
+    /// ```
+    ///
     pub const fn to_false(self) -> Option<TypeEq<B, Bool<false>>> {
         match self {
             Self::False(x) => Some(x),
-            _ => None
+            Self::True{..} => None
         }
     }
 
 
-    /// Gets a proof of `B == Bool<true>`, panics if `B == Bool<false>`
+    /// Gets a proof of `B == Bool<true>`.
+    ///
+    /// # Panic
+    ///
+    /// Panics if `B == Bool<false>`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use typewit::{const_marker::{Bool, BoolWitG}, TypeEq};
+    /// 
+    /// assert_eq!(BoolWitG::False(TypeEq::NEW).unwrap_true(), TypeEq::new::<Bool<true>>());
+    /// ```
+    ///
     pub const fn unwrap_true(self) -> TypeEq<B, Bool<true>> {
         match self {
             Self::True(x) => x,
-            _ => panic!("attempted to unwrap into True on False variant")
+            Self::False{..}  => panic!("attempted to unwrap into True on False variant")
         }
     }
 
-    /// Gets a proof of `B == Bool<false>`, panics if `B == Bool<true>`
+    /// Gets a proof of `B == Bool<false>`.
+    ///
+    /// # Panic
+    /// 
+    /// Panics if `B == Bool<true>`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use typewit::{const_marker::{Bool, BoolWitG}, TypeEq};
+    /// 
+    /// assert_eq!(BoolWitG::False(TypeEq::NEW).unwrap_false(), TypeEq::new::<Bool<false>>());
+    /// ```
+    ///
     pub const fn unwrap_false(self) -> TypeEq<B, Bool<false>> {
         match self {
             Self::False(x) => x,
-            _ => panic!("attempted to unwrap into False on True variant")
+            Self::True{..} => panic!("attempted to unwrap into False on True variant")
         }
     }
 

--- a/src/const_marker/boolwit.rs
+++ b/src/const_marker/boolwit.rs
@@ -280,7 +280,7 @@ impl<B> BoolWitG<B> {
     /// ```rust
     /// use typewit::{const_marker::{Bool, BoolWitG}, TypeEq};
     /// 
-    /// assert_eq!(BoolWitG::False(TypeEq::NEW).unwrap_true(), TypeEq::new::<Bool<true>>());
+    /// assert_eq!(BoolWitG::True(TypeEq::NEW).unwrap_true(), TypeEq::new::<Bool<true>>());
     /// ```
     ///
     pub const fn unwrap_true(self) -> TypeEq<B, Bool<true>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,6 +393,9 @@
 //! 
 //! - `"rust_stable"`: enables all the `"rust_1_*"` features.
 //! 
+//! - `"rust_1_83"`: turns functions that take mutable references into `const fn`s,
+//! and enables the `"rust_1_65"` feature.
+//! 
 //! - `"rust_1_65"`: enables the [`type_constructors`] module,
 //! the [`methods`] module,
 //! and the `"rust_1_61"` feature.
@@ -413,18 +416,6 @@
 //! enables the `"rust_stable"` crate feature,
 //! and marker types in the [`const_marker`] module that have
 //! non-primitive `const` parameters.
-//! 
-//! - `"nightly_mut_refs"`:
-//! Enables the `"rust_stable"` and `"mut_refs"` crate features,
-//! and turns functions that use mutable references into `const fn`s.
-//! 
-//! ### Future-Rust features
-//! 
-//! These features currently require future compiler versions:
-//! 
-//! - `"mut_refs"`: turns functions that take mutable references into `const fn`s.
-//! note: as of October 2023, 
-//! this crate feature requires a stable compiler from the future.
 //! 
 //! # No-std support
 //! 
@@ -452,7 +443,6 @@
 //! [`MetaBaseTypeWit`]: crate::MetaBaseTypeWit
 //! [`BaseTypeWitness`]:  crate::BaseTypeWitness
 #![no_std]
-#![cfg_attr(feature = "nightly_mut_refs", feature(const_mut_refs))]
 #![cfg_attr(feature = "adt_const_marker", feature(adt_const_params))]
 #![cfg_attr(feature = "adt_const_marker", allow(incomplete_features))]
 #![cfg_attr(feature = "docsrs", feature(doc_cfg))]

--- a/src/some_type_arg_is_ne.rs
+++ b/src/some_type_arg_is_ne.rs
@@ -8,13 +8,11 @@ use crate::{
 
 
 
-// A `TypeNe` that's impossible to soundly make, 
-// because `()` is the same type as `()`,
-// while `TypeNe` requires its type arguments not to be the same type.
-type ImpTypeNe = TypeNe<(), ()>;
+// A `TypeEq` that's used as padding for the trailing type arguments of SomeTypeArgIsNe.
+type PadTyEq = TypeEq<(), ()>;
 
 // The first TypeNe in the 4 `BaseTypeWitness` type parameters
-pub(crate) enum SomeTypeArgIsNe<A: BTW,  B: BTW, C: BTW = ImpTypeNe, D: BTW = ImpTypeNe> {
+pub(crate) enum SomeTypeArgIsNe<A: BTW,  B: BTW, C: BTW = PadTyEq, D: BTW = PadTyEq> {
     A(TypeEq<A, TypeNe<A::L, A::R>>),
     B(TypeEq<B, TypeNe<B::L, B::R>>),
     C(TypeEq<C, TypeNe<C::L, C::R>>),
@@ -41,21 +39,21 @@ impl<A: BTW, B: BTW, C: BTW, D: BTW> SomeTypeArgIsNe<A, B, C, D> {
     }
 }
 
-impl<A: BTW, B: BTW> SomeTypeArgIsNe<A, B, ImpTypeNe, ImpTypeNe> 
+impl<A: BTW, B: BTW> SomeTypeArgIsNe<A, B, PadTyEq, PadTyEq> 
 where
     A::L: Sized,
     A::R: Sized,
 {
     #[inline(always)]
     pub(crate) const fn zip2(self, _: A, _: B) -> TypeNe<(A::L, B::L), (A::R, B::R)> {
-        // SAFETY: either `A` or `B` is a TypeNe (ImpTypeNe can't be constructed),
+        // SAFETY: either `A` or `B` is a TypeNe (PadTyEq isn't a TypeNe),
         //         therefore: `(A::L, B::L) != (A::R, B::R)`.
         //         (the function parameters are needed for soundness,
         //          since `TypeNe` guarantees type inequality at the value level)
         unsafe { TypeNe::new_unchecked() }
     }
 }
-impl<A: BTW, B: BTW, C: BTW> SomeTypeArgIsNe<A, B, C, ImpTypeNe> 
+impl<A: BTW, B: BTW, C: BTW> SomeTypeArgIsNe<A, B, C, PadTyEq> 
 where
     A::L: Sized,
     A::R: Sized,
@@ -69,7 +67,7 @@ where
         _: B,
         _: C,
     ) -> TypeNe<(A::L, B::L, C::L), (A::R, B::R, C::R)> {
-        // SAFETY: either `A`, `B`, or `C is a TypeNe (ImpTypeNe can't be constructed),
+        // SAFETY: either `A`, `B`, or `C is a TypeNe (PadTyEq isn't a TypeNe),
         //         therefore: `(A::L, B::L, C::L) != (A::R, B::R, C::R)`.
         //         (the function parameters are needed for soundness,
         //          since `TypeNe` guarantees type inequality at the value level)

--- a/src/type_cmp/extra_type_cmp_methods.rs
+++ b/src/type_cmp/extra_type_cmp_methods.rs
@@ -203,14 +203,13 @@ impl<L: ?Sized, R: ?Sized> TypeCmp<L, R> {
     }
 
     crate::utils::conditionally_const!{
-        feature = "mut_refs";
+        feature = "rust_1_83";
 
         /// Converts a `TypeCmp<L, R>` to `TypeCmp<&mut L, &mut R>`
         /// 
         /// # Constness
         /// 
-        /// This requires either of the `"mut_refs"` or `"const_mut_refs"` 
-        /// crate features to be enabled to be a `const fn`.
+        /// This requires the `"rust_1_83"` crate feature to be a `const fn`.
         /// 
         /// # Example
         /// 

--- a/src/type_eq.rs
+++ b/src/type_eq.rs
@@ -990,22 +990,20 @@ impl<L: ?Sized, R: ?Sized> TypeEq<L, R> {
     }
 
     crate::utils::conditionally_const!{
-        feature = "mut_refs";
+        feature = "rust_1_83";
 
         /// Converts a `TypeEq<L, R>` to `TypeEq<&mut L, &mut R>`
         /// 
         /// # Constness
         /// 
-        /// This requires either of the `"mut_refs"` or `"const_mut_refs"` 
-        /// crate features to be enabled to be a `const fn`.
+        /// This requires the `"rust_1_83"` feature to be a `const fn`.
         /// 
         /// # Example
         /// 
         /// Because this example calls `in_mut` inside a `const fn`,
-        /// it requires either of the `"mut_refs"` or `"nightly_mut_refs"` crate features.
-        #[cfg_attr(not(feature = "mut_refs"), doc = "```ignore")]
-        #[cfg_attr(feature = "mut_refs", doc = "```rust")]
-        #[cfg_attr(feature = "nightly_mut_refs", doc = "# #![feature(const_mut_refs)]")]
+        /// it requires the `"rust_1_83"` crate feature.
+        #[cfg_attr(not(feature = "rust_1_83"), doc = "```ignore")]
+        #[cfg_attr(feature = "rust_1_83", doc = "```rust")]
         /// 
         /// use typewit::{TypeEq, type_eq};
         /// 

--- a/src/type_ne/extra_type_ne_methods.rs
+++ b/src/type_ne/extra_type_ne_methods.rs
@@ -180,14 +180,13 @@ impl<L: ?Sized, R: ?Sized> TypeNe<L, R> {
     }
 
     crate::utils::conditionally_const!{
-        feature = "mut_refs";
+        feature = "rust_1_83";
 
         /// Converts a `TypeNe<L, R>` to `TypeNe<&mut L, &mut R>`
         /// 
         /// # Constness
         /// 
-        /// This requires either of the `"mut_refs"` or `"const_mut_refs"` 
-        /// crate features to be enabled to be a `const fn`.
+        /// This requires the `"rust_1_83"` feature to be a `const fn`.
         /// 
         /// # Example
         /// 

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -1,7 +1,6 @@
 #![deny(unused_mut)]
 #![cfg_attr(feature = "adt_const_marker", feature(adt_const_params))]
 #![cfg_attr(feature = "adt_const_marker", allow(incomplete_features))]
-#![cfg_attr(feature = "nightly_mut_refs", feature(const_mut_refs))]
 
 mod misc_tests {
     mod test_utils;

--- a/tests/misc_tests/const_marker_tests.rs
+++ b/tests/misc_tests/const_marker_tests.rs
@@ -10,6 +10,8 @@ use typewit::{
 #[cfg(feature = "adt_const_marker")]
 mod slice_const_marker_tests;
 
+mod boolwit_tests;
+
 
 #[test]
 fn test_integer_const_marker() {

--- a/tests/misc_tests/const_marker_tests/boolwit_tests.rs
+++ b/tests/misc_tests/const_marker_tests/boolwit_tests.rs
@@ -1,0 +1,80 @@
+use typewit::const_marker::{Bool, BoolWitG};
+use typewit::TypeEq;
+
+#[test]
+fn is_true_test() {
+    const fn inner<B>(wit: BoolWitG<B>) -> bool {
+        wit.is_true()
+    }
+
+    assert!(inner(BoolWitG::True(TypeEq::NEW)));
+    assert!(!inner(BoolWitG::False(TypeEq::NEW)));
+}
+
+#[test]
+fn is_false_test() {
+    const fn inner<B>(wit: BoolWitG<B>) -> bool {
+        wit.is_false()
+    }
+
+    assert!(!inner(BoolWitG::True(TypeEq::NEW)));
+    assert!(inner(BoolWitG::False(TypeEq::NEW)));
+}
+
+#[test]
+fn to_true_test() {
+    const fn inner<B>(wit: BoolWitG<B>) -> Option<TypeEq<B, Bool<true>>> {
+        wit.to_true()
+    }
+
+    assert_eq!(inner(BoolWitG::True(TypeEq::NEW)), Some(TypeEq::new::<Bool<true>>()));
+    assert_eq!(inner(BoolWitG::False(TypeEq::NEW)), None);
+}
+
+#[test]
+fn to_false_test() {
+    const fn inner<B>(wit: BoolWitG<B>) -> Option<TypeEq<B, Bool<false>>> {
+        wit.to_false()
+    }
+
+    assert_eq!(inner(BoolWitG::True(TypeEq::NEW)), None);
+    assert_eq!(inner(BoolWitG::False(TypeEq::NEW)), Some(TypeEq::new::<Bool<false>>()));
+}
+
+#[test]
+fn unwrap_true_test() {
+    const fn inner<B>(wit: BoolWitG<B>) -> TypeEq<B, Bool<true>> {
+        wit.unwrap_true()
+    }
+
+    assert_eq!(inner(BoolWitG::True(TypeEq::NEW)), TypeEq::new::<Bool<true>>());
+}
+
+#[test]
+#[should_panic]
+fn unwrap_true_on_false_test() {
+    const fn inner<B>(wit: BoolWitG<B>) -> TypeEq<B, Bool<true>> {
+        wit.unwrap_true()
+    }
+
+    let _ = inner(BoolWitG::False(TypeEq::NEW));
+}
+
+#[test]
+fn unwrap_false_test() {
+    const fn inner<B>(wit: BoolWitG<B>) -> TypeEq<B, Bool<false>> {
+        wit.unwrap_false()
+    }
+
+    assert_eq!(inner(BoolWitG::False(TypeEq::NEW)), TypeEq::new::<Bool<false>>());
+}
+
+#[test]
+#[should_panic]
+fn unwrap_false_on_true_test() {
+    const fn inner<B>(wit: BoolWitG<B>) -> TypeEq<B, Bool<false>> {
+        wit.unwrap_false()
+    }
+
+    let _ = inner(BoolWitG::True(TypeEq::NEW));
+}

--- a/tests/misc_tests/misc_ui_tests/polymatch_semantic-err.stderr
+++ b/tests/misc_tests/misc_ui_tests/polymatch_semantic-err.stderr
@@ -6,3 +6,16 @@ error[E0592]: duplicate definitions with name `foo`
   |                 |
   |                 duplicate definitions for `foo`
   |                 other definition for `foo`
+
+error[E0004]: non-exhaustive patterns: `i32::MIN..=199_i32`, `201_i32..=299_i32` and `301_i32..=i32::MAX` not covered
+ --> tests/misc_tests/misc_ui_tests/polymatch_semantic-err.rs:4:26
+  |
+4 |     typewit::polymatch! {100;
+  |                          ^^^ patterns `i32::MIN..=199_i32`, `201_i32..=299_i32` and `301_i32..=i32::MAX` not covered
+  |
+  = note: the matched value is of type `i32`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+ --> src/macros/polymatch.rs
+  |
+  |             (($($pattern, i32::MIN..=199_i32 | 201_i32..=299_i32 | 301_i32..=i32::MAX => todo!())+) => $expr)
+  |                         ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/tests/misc_tests/misc_ui_tests/polymatch_syntax-err.stderr
+++ b/tests/misc_tests/misc_ui_tests/polymatch_syntax-err.stderr
@@ -8,7 +8,7 @@ error: expected arguments to be `matched expression; match arms`
   |
   = note: this error originates in the macro `typewit::polymatch` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: no rules expected the token `500`
+error: no rules expected `500`
  --> tests/misc_tests/misc_ui_tests/polymatch_syntax-err.rs:7:9
   |
 6 |         200 | 300 => 400

--- a/tests/misc_tests/simple_type_witness_macro_tests.rs
+++ b/tests/misc_tests/simple_type_witness_macro_tests.rs
@@ -1,4 +1,5 @@
 #![allow(unused_lifetimes)]
+#![allow(non_local_definitions)]
 
 #[cfg(feature = "rust_1_61")]
 use crate::misc_tests::test_utils::assert_type;

--- a/tests/misc_tests/type_cmp_tests/typecmp_extra_method_tests.rs
+++ b/tests/misc_tests/type_cmp_tests/typecmp_extra_method_tests.rs
@@ -114,7 +114,7 @@ fn test_in_ref() {
 
 #[test]
 fn test_in_mut() {
-    #[cfg(feature = "mut_refs")]
+    #[cfg(feature = "rust_1_83")]
     const fn _constness<L: ?Sized, R: ?Sized>(cmp: TypeCmp<L, R>) {
         let _ = cmp.in_mut();
     }

--- a/tests/misc_tests/type_eq_ui_tests/constructor_type_errors-err.stderr
+++ b/tests/misc_tests/type_eq_ui_tests/constructor_type_errors-err.stderr
@@ -39,6 +39,7 @@ error[E0308]: mismatched types
    |
    = note: expected struct `TypeEq<_, (dyn Debug + 'static)>`
               found struct `TypeEq<_, u8>`
+   = help: `u8` implements `Debug` so you could box the found value and coerce it to the trait object `Box<dyn Debug>`, you will have to change the expected type as well
 
 error[E0308]: mismatched types
   --> tests/misc_tests/type_eq_ui_tests/constructor_type_errors-err.rs:18:5
@@ -50,6 +51,7 @@ error[E0308]: mismatched types
    |
    = note: expected struct `TypeEq<(dyn Debug + 'static), _>`
               found struct `TypeEq<u8, _>`
+   = help: `u8` implements `Debug` so you could box the found value and coerce it to the trait object `Box<dyn Debug>`, you will have to change the expected type as well
 
 error[E0308]: mismatched types
   --> tests/misc_tests/type_eq_ui_tests/constructor_type_errors-err.rs:22:5
@@ -61,3 +63,4 @@ error[E0308]: mismatched types
    |
    = note: expected struct `TypeEq<(dyn Debug + 'static), (dyn Debug + 'static)>`
               found struct `TypeEq<u8, u8>`
+   = help: `u8` implements `Debug` so you could box the found value and coerce it to the trait object `Box<dyn Debug>`, you will have to change the expected type as well

--- a/tests/misc_tests/type_eq_ui_tests/projection_type-err.stderr
+++ b/tests/misc_tests/type_eq_ui_tests/projection_type-err.stderr
@@ -12,11 +12,6 @@ error[E0308]: mismatched types
              found struct `TypeEq<R, L>`
   = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
-help: try removing the method call
-  |
-4 -     te.flip()
-4 +     te
-  |
 
 error[E0308]: mismatched types
  --> tests/misc_tests/type_eq_ui_tests/projection_type-err.rs:8:16

--- a/tests/misc_tests/type_eq_ui_tests/projection_type_ne-err.stderr
+++ b/tests/misc_tests/type_eq_ui_tests/projection_type_ne-err.stderr
@@ -12,11 +12,6 @@ error[E0308]: mismatched types
               found struct `TypeNe<R, L>`
    = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
    = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
-help: try removing the method call
-   |
-15 -     te.flip()
-15 +     te
-   |
 
 error[E0308]: mismatched types
   --> tests/misc_tests/type_eq_ui_tests/projection_type_ne-err.rs:19:5

--- a/tests/misc_tests/type_eq_ui_tests/projection_type_ne_bound-err.stderr
+++ b/tests/misc_tests/type_eq_ui_tests/projection_type_ne_bound-err.stderr
@@ -7,13 +7,13 @@ error[E0277]: the trait bound `Mapper: RevTypeFn<[L; 1]>` is not satisfied
    |        required by a bound introduced by this call
    |
    = help: the following other types implement trait `RevTypeFn<Ret>`:
-             <FnRev<F> as RevTypeFn<R>>
-             <GRef<'a> as RevTypeFn<&'a T>>
-             <GRefMut<'a> as RevTypeFn<&'a mut T>>
-             <GBox as RevTypeFn<Box<T>>>
-             <FnIdentity as RevTypeFn<T>>
-             <Invoke<F> as RevTypeFn<R>>
-             <PhantomData<F> as RevTypeFn<R>>
+             `FnIdentity` implements `RevTypeFn<T>`
+             `FnRev<F>` implements `RevTypeFn<R>`
+             `GBox` implements `RevTypeFn<Box<T>>`
+             `GRef<'a>` implements `RevTypeFn<&'a T>`
+             `GRefMut<'a>` implements `RevTypeFn<&'a mut T>`
+             `Invoke<F>` implements `RevTypeFn<R>`
+             `PhantomData<F>` implements `RevTypeFn<R>`
    = note: required for `Mapper` to implement `InjTypeFn<L>`
 note: required by a bound in `typewit::type_ne_::<impl TypeNe<L, R>>::map`
   --> src/./type_ne/extra_type_ne_methods.rs
@@ -33,13 +33,13 @@ error[E0277]: the trait bound `Mapper: RevTypeFn<[R; 1]>` is not satisfied
    |        required by a bound introduced by this call
    |
    = help: the following other types implement trait `RevTypeFn<Ret>`:
-             <FnRev<F> as RevTypeFn<R>>
-             <GRef<'a> as RevTypeFn<&'a T>>
-             <GRefMut<'a> as RevTypeFn<&'a mut T>>
-             <GBox as RevTypeFn<Box<T>>>
-             <FnIdentity as RevTypeFn<T>>
-             <Invoke<F> as RevTypeFn<R>>
-             <PhantomData<F> as RevTypeFn<R>>
+             `FnIdentity` implements `RevTypeFn<T>`
+             `FnRev<F>` implements `RevTypeFn<R>`
+             `GBox` implements `RevTypeFn<Box<T>>`
+             `GRef<'a>` implements `RevTypeFn<&'a T>`
+             `GRefMut<'a>` implements `RevTypeFn<&'a mut T>`
+             `Invoke<F>` implements `RevTypeFn<R>`
+             `PhantomData<F>` implements `RevTypeFn<R>`
    = note: required for `Mapper` to implement `InjTypeFn<R>`
 note: required by a bound in `typewit::type_ne_::<impl TypeNe<L, R>>::map`
   --> src/./type_ne/extra_type_ne_methods.rs
@@ -59,13 +59,13 @@ error[E0277]: the trait bound `Mapper: RevTypeFn<[L; 1]>` is not satisfied
    |        required by a bound introduced by this call
    |
    = help: the following other types implement trait `RevTypeFn<Ret>`:
-             <FnRev<F> as RevTypeFn<R>>
-             <GRef<'a> as RevTypeFn<&'a T>>
-             <GRefMut<'a> as RevTypeFn<&'a mut T>>
-             <GBox as RevTypeFn<Box<T>>>
-             <FnIdentity as RevTypeFn<T>>
-             <Invoke<F> as RevTypeFn<R>>
-             <PhantomData<F> as RevTypeFn<R>>
+             `FnIdentity` implements `RevTypeFn<T>`
+             `FnRev<F>` implements `RevTypeFn<R>`
+             `GBox` implements `RevTypeFn<Box<T>>`
+             `GRef<'a>` implements `RevTypeFn<&'a T>`
+             `GRefMut<'a>` implements `RevTypeFn<&'a mut T>`
+             `Invoke<F>` implements `RevTypeFn<R>`
+             `PhantomData<F>` implements `RevTypeFn<R>`
    = note: required for `Mapper` to implement `InjTypeFn<L>`
 note: required by a bound in `typewit::type_ne_::<impl TypeNe<L, R>>::project`
   --> src/./type_ne/extra_type_ne_methods.rs
@@ -85,13 +85,13 @@ error[E0277]: the trait bound `Mapper: RevTypeFn<[R; 1]>` is not satisfied
    |        required by a bound introduced by this call
    |
    = help: the following other types implement trait `RevTypeFn<Ret>`:
-             <FnRev<F> as RevTypeFn<R>>
-             <GRef<'a> as RevTypeFn<&'a T>>
-             <GRefMut<'a> as RevTypeFn<&'a mut T>>
-             <GBox as RevTypeFn<Box<T>>>
-             <FnIdentity as RevTypeFn<T>>
-             <Invoke<F> as RevTypeFn<R>>
-             <PhantomData<F> as RevTypeFn<R>>
+             `FnIdentity` implements `RevTypeFn<T>`
+             `FnRev<F>` implements `RevTypeFn<R>`
+             `GBox` implements `RevTypeFn<Box<T>>`
+             `GRef<'a>` implements `RevTypeFn<&'a T>`
+             `GRefMut<'a>` implements `RevTypeFn<&'a mut T>`
+             `Invoke<F>` implements `RevTypeFn<R>`
+             `PhantomData<F>` implements `RevTypeFn<R>`
    = note: required for `Mapper` to implement `InjTypeFn<R>`
 note: required by a bound in `typewit::type_ne_::<impl TypeNe<L, R>>::project`
   --> src/./type_ne/extra_type_ne_methods.rs

--- a/tests/misc_tests/type_fn_ui_tests/inj_type_fn_conflicting_arguments-err.stderr
+++ b/tests/misc_tests/type_fn_ui_tests/inj_type_fn_conflicting_arguments-err.stderr
@@ -13,3 +13,27 @@ error[E0119]: conflicting implementations of trait `TypeFn<u8>` for type `Foo`
   |   conflicting implementation for `Foo`
   |
   = note: this error originates in the macro `$crate::__impl_with_span` which comes from the expansion of the macro `typewit::inj_type_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0283]: type annotations needed
+ --> tests/misc_tests/type_fn_ui_tests/inj_type_fn_conflicting_arguments-err.rs:1:1
+  |
+1 | / typewit::inj_type_fn!{
+2 | |     struct Foo;
+3 | |
+4 | |     impl u8  => u16;
+5 | |     impl<T> T => Vec<T>;
+6 | | }
+  | |_^ cannot infer type
+  |
+note: multiple `impl`s satisfying `Foo: RevTypeFn<_>` found
+ --> tests/misc_tests/type_fn_ui_tests/inj_type_fn_conflicting_arguments-err.rs:1:1
+  |
+1 | / typewit::inj_type_fn!{
+2 | |     struct Foo;
+3 | |
+4 | |     impl u8  => u16;
+5 | |     impl<T> T => Vec<T>;
+6 | | }
+  | |_^
+  = note: required for `Foo` to implement `InjTypeFn<u8>`
+  = note: this error originates in the macro `$crate::__tyfn_injtypefn_impl` which comes from the expansion of the macro `typewit::inj_type_fn` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/misc_tests/type_fn_ui_tests/inj_type_fn_from_too_generic-err.stderr
+++ b/tests/misc_tests/type_fn_ui_tests/inj_type_fn_from_too_generic-err.stderr
@@ -23,3 +23,61 @@ error[E0207]: the type parameter `I` is not constrained by the impl trait, self 
    |
 16 |     impl<I: IntoIterator> I => <I as IntoIterator>::Item;
    |          ^ unconstrained type parameter
+
+error[E0284]: type annotations needed
+ --> tests/misc_tests/type_fn_ui_tests/inj_type_fn_from_too_generic-err.rs:1:1
+  |
+1 | / typewit::inj_type_fn!{
+2 | |     struct FromTooGenericA;
+3 | |
+4 | |     impl<T, const N: usize> [T; N] => T;
+5 | | }
+  | |_^ cannot infer the value of const parameter `N`
+  |
+note: required for `FromTooGenericA` to implement `RevTypeFn<T>`
+ --> tests/misc_tests/type_fn_ui_tests/inj_type_fn_from_too_generic-err.rs:1:1
+  |
+1 | / typewit::inj_type_fn!{
+2 | |     struct FromTooGenericA;
+3 | |
+4 | |     impl<T, const N: usize> [T; N] => T;
+5 | | }
+  | |_^ unsatisfied trait bound introduced here
+  = note: required for `FromTooGenericA` to implement `InjTypeFn<[T; N]>`
+  = note: this error originates in the macro `$crate::__tyfn_injtypefn_impl` which comes from the expansion of the macro `typewit::inj_type_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+  --> tests/misc_tests/type_fn_ui_tests/inj_type_fn_from_too_generic-err.rs:7:1
+   |
+7  | / typewit::inj_type_fn!{
+8  | |     struct FromTooGenericB;
+9  | |
+10 | |     impl<T, U> (T, U) => T;
+11 | | }
+   | |_^ cannot infer type
+   |
+   = note: this error originates in the macro `$crate::__tyfn_injtypefn_impl` which comes from the expansion of the macro `typewit::inj_type_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0283]: type annotations needed
+  --> tests/misc_tests/type_fn_ui_tests/inj_type_fn_from_too_generic-err.rs:13:1
+   |
+13 | / typewit::inj_type_fn!{
+14 | |     struct IntoIteratorFn;
+15 | |
+16 | |     impl<I: IntoIterator> I => <I as IntoIterator>::Item;
+17 | | }
+   | |_^ cannot infer type
+   |
+   = note: cannot satisfy `_: IntoIterator`
+note: required for `IntoIteratorFn` to implement `RevTypeFn<<I as IntoIterator>::Item>`
+  --> tests/misc_tests/type_fn_ui_tests/inj_type_fn_from_too_generic-err.rs:13:1
+   |
+13 | / typewit::inj_type_fn!{
+14 | |     struct IntoIteratorFn;
+15 | |
+16 | |     impl<I: IntoIterator> I => <I as IntoIterator>::Item;
+   | |             ------------ unsatisfied trait bound introduced here
+17 | | }
+   | |_^
+   = note: required for `IntoIteratorFn` to implement `InjTypeFn<I>`
+   = note: this error originates in the macro `$crate::__tyfn_injtypefn_impl` which comes from the expansion of the macro `typewit::inj_type_fn` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/misc_tests/type_fn_ui_tests/type_fn_misc_syntax_errors-err.stderr
+++ b/tests/misc_tests/type_fn_ui_tests/type_fn_misc_syntax_errors-err.stderr
@@ -162,3 +162,27 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 65 |     impl<#[cfg(all())] T> () => u8
    |                        ^ unconstrained type parameter
+
+error[E0308]: mismatched types
+  --> tests/misc_tests/type_fn_ui_tests/type_fn_misc_syntax_errors-err.rs:69:1
+   |
+69 | / typewit::simple_type_witness!{
+70 | |     enum UnprovidedGenericArgsInVariant[A, B, C = u8, D = u64] {
+   | |                                               - found this type parameter
+71 | |         One[A] = (A,),
+72 | |         Three<> = (A, B, C, D),
+73 | |     }
+74 | | }
+   | | ^
+   | | |
+   | |_expected `TypeEq<(A, B, C, D), ...>`, found `TypeEq<_, _>`
+   |   arguments to this enum variant are incorrect
+   |
+   = note: expected struct `TypeEq<(A, B, C, D), (A, B, u8, u64)>`
+              found struct `TypeEq<_, _>`
+note: tuple variant defined here
+  --> tests/misc_tests/type_fn_ui_tests/type_fn_misc_syntax_errors-err.rs:72:9
+   |
+72 |         Three<> = (A, B, C, D),
+   |         ^^^^^
+   = note: this error originates in the macro `$crate::__stw_make_type_witness_impl` which comes from the expansion of the macro `typewit::simple_type_witness` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/misc_tests/type_ne_tests/typene_extra_method_tests.rs
+++ b/tests/misc_tests/type_ne_tests/typene_extra_method_tests.rs
@@ -81,7 +81,7 @@ fn in_ref_test() {
 fn in_mut_test() {
     assert_type::<_, TypeNe<&mut u8, &mut u16>>(type_ne!(u8, u16).in_mut());
 
-    #[cfg(feature = "mut_refs")]
+    #[cfg(feature = "rust_1_83")]
     {
         const fn _in_mut<T>(te: TypeNe<T, u8>) {
             let _: TypeNe<&mut T, &mut u8> = te.in_mut();

--- a/tests/misc_tests/type_ne_ui_tests/with_fn_bounds-err.stderr
+++ b/tests/misc_tests/type_ne_ui_tests/with_fn_bounds-err.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `MakeNe<_, _>: TypeFn<RightArg>` is not satisfied
+error[E0277]: the trait bound `MakeNe<_, _>: InjTypeFn<RightArg>` is not satisfied
   --> tests/misc_tests/type_ne_ui_tests/with_fn_bounds-err.rs:10:57
    |
 10 | const _: TypeNe<[i16; 0], Option<i8>> = TypeNe::with_fn(MakeNe::NEW);
@@ -7,8 +7,8 @@ error[E0277]: the trait bound `MakeNe<_, _>: TypeFn<RightArg>` is not satisfied
    |                                         required by a bound introduced by this call
    |
    = help: the following other types implement trait `TypeFn<T>`:
-             <MakeNe<T, U> as TypeFn<u32>>
-             <MakeNe<T, U> as TypeFn<LeftArg>>
+             `MakeNe<T, U>` implements `TypeFn<LeftArg>`
+             `MakeNe<T, U>` implements `TypeFn<u32>`
    = note: required for `MakeNe<_, _>` to implement `InjTypeFn<RightArg>`
 note: required by a bound in `typewit::type_ne_::<impl TypeNe<(), ()>>::with_fn`
   --> src/type_ne_.rs
@@ -23,7 +23,7 @@ error[E0271]: type mismatch resolving `<MakeNe<i8, i16> as RevTypeFn<Option<i8>>
   --> tests/misc_tests/type_ne_ui_tests/with_fn_bounds-err.rs:10:41
    |
 10 | const _: TypeNe<[i16; 0], Option<i8>> = TypeNe::with_fn(MakeNe::NEW);
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `RightArg`
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `RightArg`, found `u32`
    |
    = note: required for `MakeNe<i8, i16>` to implement `InjTypeFn<RightArg>`
 
@@ -31,9 +31,9 @@ error[E0277]: the trait bound `MakeNe<i8, i16>: TypeFn<RightArg>` is not satisfi
   --> tests/misc_tests/type_ne_ui_tests/with_fn_bounds-err.rs:10:41
    |
 10 | const _: TypeNe<[i16; 0], Option<i8>> = TypeNe::with_fn(MakeNe::NEW);
-   |                                         ^^^^^^^^^^^^^^^ the trait `TypeFn<RightArg>` is not implemented for `MakeNe<i8, i16>`
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TypeFn<RightArg>` is not implemented for `MakeNe<i8, i16>`
    |
    = help: the following other types implement trait `TypeFn<T>`:
-             <MakeNe<T, U> as TypeFn<u32>>
-             <MakeNe<T, U> as TypeFn<LeftArg>>
+             `MakeNe<T, U>` implements `TypeFn<LeftArg>`
+             `MakeNe<T, U>` implements `TypeFn<u32>`
    = note: required for `MakeNe<i8, i16>` to implement `InjTypeFn<RightArg>`

--- a/tests/misc_tests/typeeq_tests.rs
+++ b/tests/misc_tests/typeeq_tests.rs
@@ -166,7 +166,7 @@ fn in_ref_test() {
 fn in_mut_test() {
     assert_type_eq(TypeEq::new::<u8>().in_mut(), TypeEq::new::<&mut u8>());
     assert_eq!(TypeEq::new::<u8>().in_mut().to_right(&mut 5u8), &mut 5u8);
-    #[cfg(feature = "mut_refs")]
+    #[cfg(feature = "rust_1_83")]
     {
         const fn in_mut<T>(te: TypeEq<T, u8>, x: &mut T) -> &mut u8 {
             te.in_mut().to_right(x)


### PR DESCRIPTION
This PR is blocked on the Rust 1.83.0 release, and `&mut` in const not being unstabilized while that Rust version is in beta.