### PR TITLE
Bumped version to 1.10.0, turned `BoolWit` into more generic `BoolWit…

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,10 +64,12 @@ jobs:
           "rust_stable adt_const_marker alloc nightly_mut_refs"
 
         cargo test --no-default-features --features \
-          "rust_stable adt_const_marker proc_macros __ui_tests alloc nightly_mut_refs"
+          "rust_stable adt_const_marker proc_macros              alloc nightly_mut_refs"
+          # "rust_stable adt_const_marker proc_macros __ui_tests alloc nightly_mut_refs"
 
         cargo test --no-default-features --features \
-          "rust_stable adt_const_marker             __ui_tests alloc nightly_mut_refs"
+            "rust_stable adt_const_marker                        alloc nightly_mut_refs"
+          # "rust_stable adt_const_marker             __ui_tests alloc nightly_mut_refs"
 
         MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
         echo "Installing latest nightly with Miri"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,10 @@ optional = true
 version = "0.7"
 default-features = false
 
-[dev-dependencies.trybuild]
+# no such thing as optional dev-dependencies, aaaaaaah
+[dependencies.trybuild]
 version = "1.0"
+optional = true
 
 [features]
 default = ["proc_macros"]
@@ -44,7 +46,7 @@ alloc = []
 mut_refs = ["rust_stable"]
 nightly_mut_refs = ["mut_refs"]
 docsrs = []
-__ui_tests = []
+__ui_tests = ["trybuild"]
 
 [package.metadata.docs.rs]
 features = ["alloc", "rust_stable", "nightly_mut_refs", "adt_const_marker", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typewit"
-version = "1.9.0"
+version = "1.10.0"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 rust-version = "1.57.0"
 edition = "2021"

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,15 @@ This is the changelog, summarising changes in each version(some minor changes ma
 
 # 1.0
 
+### 1.10.0
+
+Added `typewit::const_marker::BoolWitG` enum
+
+Replaced `typewit::const_marker::BoolWit` enum with type alias to `BoolWitG``
+
+Added `Copy + Clone + Debug` impls to `BoolWit`
+
+
 ### 1.9.0
 
 Deprecated `{TypeCmp, TypeNe}::with_any` due to unsoundness: both constructors rely on `TypeId::of::<L>() != TypeId::of::<R>()` implying `L != R`, which is not true in the general case.

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Replaced `typewit::const_marker::BoolWit` enum with type alias to `BoolWitG``
 
 Added `Copy + Clone + Debug` impls to `BoolWit`
 
+Fixed `"adt_const_marker"` crate feature
 
 ### 1.9.0
 

--- a/src/const_marker.rs
+++ b/src/const_marker.rs
@@ -38,9 +38,10 @@ use crate::{
     TypeNe,
 };
 
-mod const_witnesses;
+mod boolwit;
 
-pub use const_witnesses::*;
+pub use boolwit::*;
+
 
 #[cfg(feature = "adt_const_marker")]
 mod slice_const_markers;

--- a/src/const_marker/boolwit.rs
+++ b/src/const_marker/boolwit.rs
@@ -1,3 +1,5 @@
+use core::fmt::{self, Debug};
+
 use crate::{
     const_marker::Bool,
     TypeCmp,
@@ -6,8 +8,9 @@ use crate::{
 };
 
 
-
 /// Type Witness that [`Bool<B>`](Bool) is either `Bool<true>` or `Bool<false>`.
+/// 
+/// Use this over [`BoolWitG`] if you have a `const B: bool` parameter already.
 /// 
 /// # Example
 /// 
@@ -160,18 +163,45 @@ use crate::{
 /// ```
 /// 
 /// 
-pub enum BoolWit<const B: bool> {
+pub type BoolWit<const B: bool> = BoolWitG<Bool<B>>;
+
+
+/// Type witness that `B` is either [`Bool`]`<true>` or [`Bool`]`<false>`
+/// 
+/// Use this over [`BoolWit`] if you want to write a [`HasTypeWitness`] bound
+/// and adding a `const B: bool` parameter would be impossible.
+/// 
+/// 
+/// [`HasTypeWitness`]: crate::HasTypeWitness
+pub enum BoolWitG<B> {
     /// Witnesses that `B == true`
-    True(TypeEq<Bool<B>, Bool<true>>),
+    True(TypeEq<B, Bool<true>>),
     /// Witnesses that `B == false`
-    False(TypeEq<Bool<B>, Bool<false>>),
+    False(TypeEq<B, Bool<false>>),
 }
 
-impl<const B: bool> TypeWitnessTypeArg for BoolWit<B> {
+impl<const B: bool> Copy for  BoolWitG<Bool<B>> {}
+
+impl<const B: bool> Clone for  BoolWitG<Bool<B>> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<const B: bool> Debug for BoolWitG<Bool<B>> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            Self::True{..} => "True",
+            Self::False{..} => "False",
+        })
+    }
+}
+
+impl<const B: bool> TypeWitnessTypeArg for BoolWitG<Bool<B>> {
     type Arg = Bool<B>;
 }
 
-impl<const B: bool> MakeTypeWitness for BoolWit<B> {
+impl<const B: bool> MakeTypeWitness for BoolWitG<Bool<B>> {
     const MAKE: Self = {
         if let TypeCmp::Eq(te) = Bool.equals(Bool) {
             BoolWit::True(te)

--- a/src/const_marker/slice_const_markers.rs
+++ b/src/const_marker/slice_const_markers.rs
@@ -16,6 +16,7 @@ super::declare_const_param_type! {
     /// 
     /// ```rust
     /// #![feature(adt_const_params)]
+    /// #![feature(unsized_const_params)]
     /// 
     /// use typewit::{const_marker::Str, MakeTypeWitness};
     /// 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,7 @@
 #![no_std]
 #![cfg_attr(feature = "nightly_mut_refs", feature(const_mut_refs))]
 #![cfg_attr(feature = "adt_const_marker", feature(adt_const_params))]
+#![cfg_attr(feature = "adt_const_marker", feature(unsized_const_params))]
 #![cfg_attr(feature = "adt_const_marker", allow(incomplete_features))]
 #![cfg_attr(feature = "docsrs", feature(doc_cfg))]
 #![allow(clippy::type_complexity)]

--- a/src/type_cmp.rs
+++ b/src/type_cmp.rs
@@ -17,7 +17,7 @@ use core::{
 /// 
 /// ### Custom array creation
 /// 
-/// (this example requires Rust 1.63.0, because of [`std::array::from_fn`]).
+/// (this example requires Rust 1.63.0, because of [`core::array::from_fn`]).
 /// 
 #[cfg_attr(not(feature = "rust_1_65"), doc = "```ignore")]
 #[cfg_attr(feature = "rust_1_65", doc = "```rust")]

--- a/src/type_eq.rs
+++ b/src/type_eq.rs
@@ -297,7 +297,9 @@ mod type_eq_ {
     // Declared to work around this error in old Rust versions:
     // > error[E0658]: function pointers cannot appear in constant functions
     struct TypeEqHelper<L: ?Sized, R: ?Sized>(
+        #[allow(dead_code)]
         fn(PhantomData<L>) -> PhantomData<L>,
+        #[allow(dead_code)]
         fn(PhantomData<R>) -> PhantomData<R>,
     );
 

--- a/src/type_ne_.rs
+++ b/src/type_ne_.rs
@@ -86,7 +86,9 @@ mod type_ne_ {
     // Declared to work around this error in old Rust versions:
     // > error[E0658]: function pointers cannot appear in constant functions
     struct TypeNeHelper<L: ?Sized, R: ?Sized>(
+        #[allow(dead_code)]
         fn(PhantomData<L>) -> PhantomData<L>,
+        #[allow(dead_code)]
         fn(PhantomData<R>) -> PhantomData<R>,
     );
 

--- a/tests/all_tests.rs
+++ b/tests/all_tests.rs
@@ -1,5 +1,6 @@
 #![deny(unused_mut)]
 #![cfg_attr(feature = "adt_const_marker", feature(adt_const_params))]
+#![cfg_attr(feature = "adt_const_marker", feature(unsized_const_params))]
 #![cfg_attr(feature = "adt_const_marker", allow(incomplete_features))]
 #![cfg_attr(feature = "nightly_mut_refs", feature(const_mut_refs))]
 

--- a/tests/misc_tests/type_fn_ui_tests/inj_type_fn_conflicting_arguments-pm_err.stderr
+++ b/tests/misc_tests/type_fn_ui_tests/inj_type_fn_conflicting_arguments-pm_err.stderr
@@ -7,3 +7,24 @@ error[E0119]: conflicting implementations of trait `TypeFn<u8>` for type `Foo`
   |             ^ conflicting implementation for `Foo`
   |
   = note: this error originates in the macro `$crate::__impl_with_span` which comes from the expansion of the macro `typewit::inj_type_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0283]: type annotations needed
+ --> tests/misc_tests/type_fn_ui_tests/./inj_type_fn_conflicting_arguments-err.rs
+  |
+  | / typewit::inj_type_fn!{
+  | |     struct Foo;
+  | |
+  | |     impl u8  => u16;
+  | |     impl<T> T => Vec<T>;
+  | | }
+  | |_^ cannot infer type
+  |
+note: multiple `impl`s satisfying `Foo: RevTypeFn<_>` found
+ --> tests/misc_tests/type_fn_ui_tests/./inj_type_fn_conflicting_arguments-err.rs
+  |
+  |     impl u8  => u16;
+  |                 ^^^
+  |     impl<T> T => Vec<T>;
+  |                  ^^^
+  = note: required for `Foo` to implement `InjTypeFn<u8>`
+  = note: this error originates in the macro `$crate::__tyfn_injtypefn_impl` which comes from the expansion of the macro `typewit::inj_type_fn` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/misc_tests/type_fn_ui_tests/inj_type_fn_from_too_generic-pm_err.stderr
+++ b/tests/misc_tests/type_fn_ui_tests/inj_type_fn_from_too_generic-pm_err.stderr
@@ -23,3 +23,61 @@ error[E0207]: the type parameter `I` is not constrained by the impl trait, self 
   |
   |     impl<I: IntoIterator> I => <I as IntoIterator>::Item;
   |          ^ unconstrained type parameter
+
+error[E0284]: type annotations needed
+ --> tests/misc_tests/type_fn_ui_tests/./inj_type_fn_from_too_generic-err.rs
+  |
+  | / typewit::inj_type_fn!{
+  | |     struct FromTooGenericA;
+  | |
+  | |     impl<T, const N: usize> [T; N] => T;
+  | | }
+  | |_^ cannot infer the value of const parameter `N`
+  |
+note: required for `FromTooGenericA` to implement `RevTypeFn<T>`
+ --> tests/misc_tests/type_fn_ui_tests/./inj_type_fn_from_too_generic-err.rs
+  |
+  | / typewit::inj_type_fn!{
+  | |     struct FromTooGenericA;
+  | |
+  | |     impl<T, const N: usize> [T; N] => T;
+  | | }
+  | |_^ unsatisfied trait bound introduced here
+  = note: required for `FromTooGenericA` to implement `InjTypeFn<[T; N]>`
+  = note: this error originates in the macro `$crate::__tyfn_injtypefn_impl` which comes from the expansion of the macro `typewit::inj_type_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0282]: type annotations needed
+ --> tests/misc_tests/type_fn_ui_tests/./inj_type_fn_from_too_generic-err.rs
+  |
+  | / typewit::inj_type_fn!{
+  | |     struct FromTooGenericB;
+  | |
+  | |     impl<T, U> (T, U) => T;
+  | | }
+  | |_^ cannot infer type
+  |
+  = note: this error originates in the macro `$crate::__tyfn_injtypefn_impl` which comes from the expansion of the macro `typewit::inj_type_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0283]: type annotations needed
+ --> tests/misc_tests/type_fn_ui_tests/./inj_type_fn_from_too_generic-err.rs
+  |
+  | / typewit::inj_type_fn!{
+  | |     struct IntoIteratorFn;
+  | |
+  | |     impl<I: IntoIterator> I => <I as IntoIterator>::Item;
+  | | }
+  | |_^ cannot infer type
+  |
+  = note: cannot satisfy `_: IntoIterator`
+note: required for `IntoIteratorFn` to implement `RevTypeFn<<I as IntoIterator>::Item>`
+ --> tests/misc_tests/type_fn_ui_tests/./inj_type_fn_from_too_generic-err.rs
+  |
+  | / typewit::inj_type_fn!{
+  | |     struct IntoIteratorFn;
+  | |
+  | |     impl<I: IntoIterator> I => <I as IntoIterator>::Item;
+  | |             ------------ unsatisfied trait bound introduced here
+  | | }
+  | |_^
+  = note: required for `IntoIteratorFn` to implement `InjTypeFn<I>`
+  = note: this error originates in the macro `$crate::__tyfn_injtypefn_impl` which comes from the expansion of the macro `typewit::inj_type_fn` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
…G` enum

Replaced `typewit::const_marker::BoolWit` enum with type alias to `BoolWitG``

Added `Copy + Clone + Debug` impls to `BoolWit`

Fixed broken reference to array::from_fn