### PR TITLE
1.14.2 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typewit"
-version = "1.14.1"
+version = "1.14.2"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 rust-version = "1.57.0"
 edition = "2021"

--- a/src/const_marker/const_marker_eq_traits.rs
+++ b/src/const_marker/const_marker_eq_traits.rs
@@ -1,4 +1,4 @@
-use crate::{TypeCmp, TypeWitnessTypeArg, MakeTypeWitness};
+use crate::{Identity, TypeCmp, TypeWitnessTypeArg, MakeTypeWitness};
 use crate::const_marker::{ConstMarkerOf, ConstMarker};
 
 
@@ -348,11 +348,8 @@ pub trait ConstMarkerHasWitness: ConstMarker<Of: HasConstMarker> {
     const CM_WITNESS: <Self::Of as HasConstMarker>::Witness<Self>;
 
     #[doc(hidden)]
-    const __SEAL__: __DerivesConstMarkerHasWitness<Self>;
+    type __Seal__: MakeTypeWitness + Identity<Type = <Self::Of as HasConstMarker>::Witness<Self>>;
 }
-
-#[doc(hidden)]
-pub struct __DerivesConstMarkerHasWitness<T>(core::marker::PhantomData<T>);
 
 
 impl<CM> ConstMarkerHasWitness for CM
@@ -363,8 +360,7 @@ where
     const CM_WITNESS: <Self::Of as HasConstMarker>::Witness<Self> = MakeTypeWitness::MAKE;
 
     #[doc(hidden)]
-    const __SEAL__: __DerivesConstMarkerHasWitness<Self> = 
-        __DerivesConstMarkerHasWitness(core::marker::PhantomData);
+    type __Seal__ = <Self::Of as HasConstMarker>::Witness<Self>;
 }
 
 

--- a/src/type_ne/extra_type_ne_methods.rs
+++ b/src/type_ne/extra_type_ne_methods.rs
@@ -4,6 +4,7 @@ use alloc::boxed::Box;
 
 use crate::type_fn::{InjTypeFn, InvokeAlias, CallInjFn, UncallFn};
 
+#[cfg(feature = "rust_1_61")]
 use crate::const_marker::Usize;
 
 


### PR DESCRIPTION
Changed how `ConstMarkerHasWitness` is sealed from an assoc const to use a bound, This prevents malicious implementations that diverge instead of producing the constant.