### PR TITLE
Fixed inclusion of serde impls on docs.rs documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typewit"
-version = "1.15.1"
+version = "1.15.2"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 rust-version = "1.57.0"
 edition = "2021"
@@ -74,5 +74,13 @@ __test_doc_lints = []
 __ui_tests = ["trybuild"]
 
 [package.metadata.docs.rs]
-features = ["alloc", "rust_stable", "adt_const_marker", "generic_const_exprs", "docsrs"]
+features = [
+    "alloc", 
+    "rust_stable", 
+    "adt_const_marker", 
+    "generic_const_exprs", 
+    "serde", 
+    "serde_json", 
+    "docsrs",
+]
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@ This is the changelog, summarising changes in each version(some minor changes ma
 
 # 1.0
 
+### 1.15.2
+
+Fixed inclusion of serde impls on docs.rs documentation
+
 ### 1.15.1
 
 Fixed support for de/serializing into non-self-describing formats

--- a/src/const_marker.rs
+++ b/src/const_marker.rs
@@ -400,3 +400,40 @@ declare_const_param_type!{I64(i64) int,}
 declare_const_param_type!{I128(i128) int,}
 declare_const_param_type!{Isize(isize) int,}
 
+
+
+
+
+
+
+
+
+
+
+
+macro_rules! __const_marker_deserialize_doc_example {
+    (int $struct:ident $example_ty:literal) => {concat!(
+        "```", $example_ty, "\n",
+        "use typewit::const_marker::", stringify!($struct), "; \n",
+        " \n",
+        "assert_eq!(serde_json::from_str::<",
+        stringify!($struct), 
+        "<1>>(\"1\").unwrap(), ",
+        stringify!($struct),
+        "::<1>); \n",
+        " \n",
+        "// trying to deserialize `", stringify!($struct),
+        "<1>` from any value other than `1` produces an error \n",
+        "assert!(serde_json::from_str::<", stringify!($struct), "<1>>(\"0\").is_err()); \n",
+        " \n",
+        " \n",
+        "assert_eq!(serde_json::to_string(&", stringify!($struct), "::<1>).unwrap(), \"1\"); \n",
+        " \n",
+        "assert_eq!(serde_json::to_string(&", stringify!($struct), "::<92>).unwrap(), \"92\"); \n",
+        " \n",
+        "```"
+    )};
+    ($other:ident $struct:ident $example_ty:tt) => { "" };
+}
+
+pub(crate) use __const_marker_deserialize_doc_example;

--- a/src/const_marker.rs
+++ b/src/const_marker.rs
@@ -136,6 +136,24 @@ macro_rules! __declare_const_param_type {
         /// 
         /// When the `"serde"` feature is enabled, 
         /// this type is serialized/deserialized as the `VAL` const parameter.
+        /// 
+        #[cfg_attr(
+            all(feature = "serde", feature = "serde_json"),
+            doc = $crate::const_marker::__const_marker_deserialize_doc_example!(
+                $deser_type
+                $struct
+                "rust"
+            )
+        )]
+        #[cfg_attr(
+            not(all(feature = "serde", feature = "serde_json")),
+            doc = $crate::const_marker::__const_marker_deserialize_doc_example!(
+                $deser_type
+                $struct
+                "ignore"
+            )
+        )]
+        /// 
         $(#[$struct_docs])*
         #[derive(Copy, Clone)]
         pub struct $struct<const VAL: $prim>;
@@ -273,15 +291,15 @@ declare_const_param_type!{
 }
 declare_const_param_type!{Char(char) primitive,}
 
-declare_const_param_type!{U8(u8) primitive,}
-declare_const_param_type!{U16(u16) primitive,}
-declare_const_param_type!{U32(u32) primitive,}
-declare_const_param_type!{U64(u64) primitive,}
-declare_const_param_type!{U128(u128) primitive,}
+declare_const_param_type!{U8(u8) int,}
+declare_const_param_type!{U16(u16) int,}
+declare_const_param_type!{U32(u32) int,}
+declare_const_param_type!{U64(u64) int,}
+declare_const_param_type!{U128(u128) int,}
 
 declare_const_param_type!{
     Usize(usize)
-    primitive,
+    int,
 
     /// # Examples
     /// 
@@ -375,10 +393,10 @@ declare_const_param_type!{
     fn equals;
 }
 
-declare_const_param_type!{I8(i8) primitive,}
-declare_const_param_type!{I16(i16) primitive,}
-declare_const_param_type!{I32(i32) primitive,}
-declare_const_param_type!{I64(i64) primitive,}
-declare_const_param_type!{I128(i128) primitive,}
-declare_const_param_type!{Isize(isize) primitive,}
+declare_const_param_type!{I8(i8) int,}
+declare_const_param_type!{I16(i16) int,}
+declare_const_param_type!{I32(i32) int,}
+declare_const_param_type!{I64(i64) int,}
+declare_const_param_type!{I128(i128) int,}
+declare_const_param_type!{Isize(isize) int,}
 

--- a/src/const_marker/const_marker_serde_impls.rs
+++ b/src/const_marker/const_marker_serde_impls.rs
@@ -49,35 +49,6 @@ pub(crate) use __declare_const_marker_serde_impls;
 
 //////////////
 
-
-macro_rules! __const_marker_deserialize_doc_example {
-    (int $struct:ident $example_ty:literal) => {concat!(
-        "```", $example_ty, "\n",
-        "use typewit::const_marker::", stringify!($struct), "; \n",
-        " \n",
-        "assert_eq!(serde_json::from_str::<",
-        stringify!($struct), 
-        "<1>>(\"1\").unwrap(), ",
-        stringify!($struct),
-        "::<1>); \n",
-        " \n",
-        "// trying to deserialize `", stringify!($struct),
-        "<1>` from any value other than `1` produces an error \n",
-        "assert!(serde_json::from_str::<", stringify!($struct), "<1>>(\"0\").is_err()); \n",
-        " \n",
-        " \n",
-        "assert_eq!(serde_json::to_string(&", stringify!($struct), "::<1>).unwrap(), \"1\"); \n",
-        " \n",
-        "assert_eq!(serde_json::to_string(&", stringify!($struct), "::<92>).unwrap(), \"92\"); \n",
-        " \n",
-        "```"
-    )};
-    ($other:ident $struct:ident $example_ty:tt) => { "" };
-}
-
-pub(crate) use __const_marker_deserialize_doc_example;
-
-
 macro_rules! __const_marker_deserialize_seed_impl {
     ($(int)? $(primitive)? => $seed:ident, $deser:ident, $ty:ty) => {
         CheckExpected {

--- a/src/const_marker/const_marker_serde_impls.rs
+++ b/src/const_marker/const_marker_serde_impls.rs
@@ -50,8 +50,36 @@ pub(crate) use __declare_const_marker_serde_impls;
 //////////////
 
 
+macro_rules! __const_marker_deserialize_doc_example {
+    (int $struct:ident $example_ty:literal) => {concat!(
+        "```", $example_ty, "\n",
+        "use typewit::const_marker::", stringify!($struct), "; \n",
+        " \n",
+        "assert_eq!(serde_json::from_str::<",
+        stringify!($struct), 
+        "<1>>(\"1\").unwrap(), ",
+        stringify!($struct),
+        "::<1>); \n",
+        " \n",
+        "// trying to deserialize `", stringify!($struct),
+        "<1>` from any value other than `1` produces an error \n",
+        "assert!(serde_json::from_str::<", stringify!($struct), "<1>>(\"0\").is_err()); \n",
+        " \n",
+        " \n",
+        "assert_eq!(serde_json::to_string(&", stringify!($struct), "::<1>).unwrap(), \"1\"); \n",
+        " \n",
+        "assert_eq!(serde_json::to_string(&", stringify!($struct), "::<92>).unwrap(), \"92\"); \n",
+        " \n",
+        "```"
+    )};
+    ($other:ident $struct:ident $example_ty:tt) => { "" };
+}
+
+pub(crate) use __const_marker_deserialize_doc_example;
+
+
 macro_rules! __const_marker_deserialize_seed_impl {
-    (primitive => $seed:ident, $deser:ident, $ty:ty) => {
+    ($(int)? $(primitive)? => $seed:ident, $deser:ident, $ty:ty) => {
         CheckExpected {
             expected: $seed.equals_to,
             found: &<$ty as serde_::Deserialize>::deserialize($deser)?,


### PR DESCRIPTION
Bumped version to 1.15.2

Added docs that show how integer const marker types are de/serialized